### PR TITLE
Add jenkins.sh job

### DIFF
--- a/email_alert_notifications/jenkins.sh
+++ b/email_alert_notifications/jenkins.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+export FILE_TO_UPLOAD=rename_email_files_with_request_id.py.zip
+rm -f $FILE_TO_UPLOAD
+/usr/bin/zip $FILE_TO_UPLOAD rename_email_files_with_request_id.py
+echo "$FILE_TO_UPLOAD ready to upload"


### PR DESCRIPTION
This just creates a zip of the code ready for deployment, and exports a variable which is used by a Jenkins job for triggering deployment.

Related: https://github.com/alphagov/govuk-puppet/pull/4427
Further related: https://github.com/alphagov/govuk-terraform-provisioning/pull/46