### PR TITLE
Add filter to logs

### DIFF
--- a/download-lambda-logs/handler.py
+++ b/download-lambda-logs/handler.py
@@ -4,12 +4,15 @@ from urllib.parse import unquote
 from download_logs.aws_lambda import AWSLambda
 
 EVENT_REGEX = re.compile(r'^ObjectCreated:')
+DOWNLOAD_REGEX = re.compile(r'^whitehall_assets/')
 
 
 def handle_lambda(event, context):
     if event['Records']:
         for record in event['Records']:
-            if EVENT_REGEX.match(record['eventName']):
+            file_created = EVENT_REGEX.match(record['eventName'])
+            is_download_event = DOWNLOAD_REGEX.match(record['s3']["object"]["key"])
+            if file_created and is_download_event:
                 bucket_name = record['s3']['bucket']['name']
                 bucket_key = unquote(record['s3']['object']['key'])
                 runner = AWSLambda(bucket_name, bucket_key)


### PR DESCRIPTION
This will only scan files in the 'whitehall_assets' subfolder, which in s3 is part of the filename as a prefix.

For: [Trello card](https://trello.com/c/sbJeB8PO/152-event-all-downloads-investigate)