### PR TITLE
Download logs improvements

### DIFF
--- a/download-lambda-logs/download_logs/base.py
+++ b/download-lambda-logs/download_logs/base.py
@@ -1,6 +1,3 @@
-import re
-
-
 class Base(object):
 
     def __init__(self, filename):
@@ -16,20 +13,4 @@ class Base(object):
         raise NotImplementedError
 
     def transform_row(self, row):
-        try:
-            timestamp, status, file_downloaded, ip, referrer, user_agent, ga_client_id = row
-            if re.search('https://www.gov.uk/', referrer) is None:
-                return {
-                    'timestamp': timestamp,
-                    'status': status,
-                    'file_downloaded': file_downloaded,
-                    'ip': ip,
-                    'referrer': referrer,
-                    'user_agent': user_agent,
-                    'ga_client_id': ga_client_id
-                }
-            else:
-                return ""
-        except:
-            print(row)
-            raise
+        raise NotImplementedError

--- a/download-lambda-logs/download_logs/tests/aws_lambda_test.py
+++ b/download-lambda-logs/download_logs/tests/aws_lambda_test.py
@@ -4,6 +4,8 @@ import csv
 import requests
 from collections import deque
 from mock import MagicMock
+import urllib.parse
+import grequests
 
 from download_logs.aws_lambda import AWSLambda
 
@@ -86,7 +88,7 @@ def test_parse_client_id():
     assert_equal(client_id, expected)
 
 
-def test_mock_send_event_to_GA():
+def test_mock_construct_url():
     download_data = {'timestamp': '1495792859',
                      'status': '200',
                      'file_downloaded': '/government/uploads/system/uploads/attachment_data/file/417696/Archived-information_sharing_guidance_for_practitioners_and_managers.pdf',
@@ -97,11 +99,22 @@ def test_mock_send_event_to_GA():
 
     aws_lambda = AWSLambda("MockBucket", "2017-05-26T10-00-00.000-wZe41G6PdJYziQ8AAAAA.log")
 
-    requests.post = MagicMock(return_value="OK")
+    url = aws_lambda.construct_url(download_data)
 
-    response = aws_lambda.send_event_to_GA(download_data)
+    params = urllib.parse.urlencode({
+                                    'v': 1,
+                                    'tid': 'UA-26179049-7',
+                                    'cid': '1111111111.1111111111',
+                                    't': 'event',
+                                    'ec': 'Download from External Source',
+                                    'ea': '/government/uploads/system/uploads/attachment_data/file/417696/Archived-information_sharing_guidance_for_practitioners_and_managers.pdf',
+                                    'el': 'https://www.bing.com/',
+                                    'cd13': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586',
+                                    'ua': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586'
+                                    })
+    expected_url = "http://www.google-analytics.com/collect?{0}".format(params)
 
-    assert_is_not_none(response)
+    assert_equal(url, expected_url)
 
 
 def test_mock_send_events_to_GA():
@@ -115,8 +128,10 @@ def test_mock_send_events_to_GA():
 
     aws_lambda = AWSLambda("MockBucket", "2017-05-26T10-00-00.000-wZe41G6PdJYziQ8AAAAA.log")
     aws_lambda.process = MagicMock(return_value=processed_values)
-    aws_lambda.send_event_to_GA = MagicMock(return_value="OK")
+    aws_lambda.construct_url = MagicMock(return_value="http://www.google-analytics.com/collect?{0}")
+
+    grequests.map = MagicMock(return_value=["<Response [200]>"])
 
     response = aws_lambda.send_events_to_GA()
 
-    assert_is_not_none(response)
+    assert_equal(response, ["<Response [200]>"])

--- a/download-lambda-logs/download_logs/tests/aws_lambda_test.py
+++ b/download-lambda-logs/download_logs/tests/aws_lambda_test.py
@@ -87,7 +87,7 @@ def test_parse_client_id():
     assert_equal(client_id, expected)
 
 
-def test_mock_construct_url():
+def test_construct_url():
     property_id = 'UA-26179049-7'
     ga_client_id = '1111111111.1111111111'
     user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586'
@@ -106,10 +106,11 @@ def test_mock_construct_url():
     aws_lambda = AWSLambda("MockBucket", "2017-05-26T10-00-00.000-wZe41G6PdJYziQ8AAAAA.log")
 
     url = aws_lambda.construct_url(download_data)
+    latency = aws_lambda.calculate_time_delta(download_data['timestamp'])
 
     params = urllib.parse.urlencode({
                                     'v': 1,
-                                    'tid': 'UA-26179049-7',
+                                    'tid': property_id,
                                     'cid': ga_client_id,
                                     't': 'event',
                                     'ec': 'Download from External Source',
@@ -119,14 +120,15 @@ def test_mock_construct_url():
                                     'uip': ip,
                                     'dr': referrer,
                                     'cd13': user_agent,
-                                    'cd14': ga_client_id
+                                    'cd14': ga_client_id,
+                                    'qt': latency
                                     })
     expected_url = "http://www.google-analytics.com/collect?{0}".format(params)
 
     assert_equal(url, expected_url)
 
 
-def test_mock_send_events_to_GA():
+def test_send_events_to_GA():
     processed_values = [{'timestamp': '1495792859',
                          'status': '200',
                          'file_downloaded': '/government/uploads/system/uploads/attachment_data/file/417696/Archived-information_sharing_guidance_for_practitioners_and_managers.pdf',

--- a/download-lambda-logs/download_logs/tests/aws_lambda_test.py
+++ b/download-lambda-logs/download_logs/tests/aws_lambda_test.py
@@ -1,7 +1,6 @@
-from nose.tools import assert_equal, assert_is_not_none
+from nose.tools import assert_equal
 import os
 import csv
-import requests
 from collections import deque
 from mock import MagicMock
 import urllib.parse
@@ -89,13 +88,20 @@ def test_parse_client_id():
 
 
 def test_mock_construct_url():
+    property_id = 'UA-26179049-7'
+    ga_client_id = '1111111111.1111111111'
+    user_agent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586'
+    file = '/government/uploads/system/uploads/attachment_data/file/417696/Archived-information_sharing_guidance_for_practitioners_and_managers.pdf'
+    referrer = 'https://www.bing.com/'
+    ip = '11.111.111.111'
+
     download_data = {'timestamp': '1495792859',
                      'status': '200',
-                     'file_downloaded': '/government/uploads/system/uploads/attachment_data/file/417696/Archived-information_sharing_guidance_for_practitioners_and_managers.pdf',
-                     'ip': '11.111.111.111',
-                     'referrer': 'https://www.bing.com/',
-                     'user_agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586',
-                     'ga_client_id': '1111111111.1111111111'}
+                     'file_downloaded': file,
+                     'ip': ip,
+                     'referrer': referrer,
+                     'user_agent': user_agent,
+                     'ga_client_id': ga_client_id}
 
     aws_lambda = AWSLambda("MockBucket", "2017-05-26T10-00-00.000-wZe41G6PdJYziQ8AAAAA.log")
 
@@ -104,13 +110,16 @@ def test_mock_construct_url():
     params = urllib.parse.urlencode({
                                     'v': 1,
                                     'tid': 'UA-26179049-7',
-                                    'cid': '1111111111.1111111111',
+                                    'cid': ga_client_id,
                                     't': 'event',
                                     'ec': 'Download from External Source',
-                                    'ea': '/government/uploads/system/uploads/attachment_data/file/417696/Archived-information_sharing_guidance_for_practitioners_and_managers.pdf',
-                                    'el': 'https://www.bing.com/',
-                                    'cd13': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586',
-                                    'ua': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586'
+                                    'ea': file,
+                                    'el': referrer,
+                                    'ua': user_agent,
+                                    'uip': ip,
+                                    'dr': referrer,
+                                    'cd13': user_agent,
+                                    'cd14': ga_client_id
                                     })
     expected_url = "http://www.google-analytics.com/collect?{0}".format(params)
 


### PR DESCRIPTION
For: [Trello card](https://trello.com/c/b3Mmvo9M/182-event-all-downloads-improvements)

## Improvements

1. **Accurate reporting**
The hit times weren't being reported correctly - they all occured on the 10 minute mark when the function runs. We're using Queue Time functionality to fix this https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt

2. **Implement Asynchronous Requests**
The script takes over 40 seconds to process each log file. Lambda is billed by the millisecond, so any time savings would really help. The python Requests library supports concurrent requests by default, so we're adding concurrency: http://docs.python-requests.org/en/v0.10.6/user/advanced/#asynchronous-requests

3. **Send more information**
* send real IP
* also send the referrer in a dedicated param (`dr`), not just through the event label:  https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dr