### PR TITLE
Add a script to deploy the function

### DIFF
--- a/download-lambda-logs/.gitignore
+++ b/download-lambda-logs/.gitignore
@@ -1,2 +1,3 @@
 .venv
 *.pyc
+function.zip

--- a/download-lambda-logs/binary_requirements.txt
+++ b/download-lambda-logs/binary_requirements.txt
@@ -1,0 +1,2 @@
+gevent==1.2.2
+greenlet==0.4.12

--- a/download-lambda-logs/deploy.sh
+++ b/download-lambda-logs/deploy.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+rm -rf .venv function.zip
+
+virtualenv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
+zip -r function.zip download_logs handler.py -x *.pyc -x *.log
+(
+  cd .venv/lib/python3.6/site-packages
+  zip -r ../../../../function.zip * -x *.pyc
+)
+
+pip download --platform manylinux1_x86_64 --only-binary :all: --abi cp36m $(cat binary_requirements.txt)
+mkdir -p wheelhouse
+ls *.whl | xargs -I '{}' -n1 unzip {} -d wheelhouse
+rm *.whl
+(
+  cd wheelhouse
+  zip -r ../function.zip *
+)
+rm -rf wheelhouse
+
+aws lambda update-function-code --function-name DownloadLogsAnalytics --zip-file fileb://function.zip --publish
+
+rm function.zip

--- a/download-lambda-logs/requirements.txt
+++ b/download-lambda-logs/requirements.txt
@@ -1,0 +1,13 @@
+boto3==1.4.4
+botocore==1.5.78
+certifi==2017.4.17
+chardet==3.0.4
+docutils==0.13.1
+grequests==0.3.0
+idna==2.5
+jmespath==0.9.3
+python-dateutil==2.6.0
+requests==2.18.1
+s3transfer==0.1.10
+six==1.10.0
+urllib3==1.21.1


### PR DESCRIPTION
Uses manylinux wheels to provide Lambda compatible binaries for native
packages like gevent and greenlet
Assumes your local environment has the credentials required to access
the GOV.UK AWS account