### PR TITLE
Upload lambda artefact to S3

### DIFF
--- a/send_public_api_events_to_ga/deploy.sh
+++ b/send_public_api_events_to_ga/deploy.sh
@@ -22,6 +22,11 @@ rm *.whl
 )
 rm -rf wheelhouse
 
-aws lambda update-function-code --function-name SendPublicAPIEventsToGA --zip-file fileb://function.zip --publish
+# Manual way to deploy lambda function code
+# aws lambda update-function-code --function-name SendPublicAPIEventsToGA --zip-file fileb://function.zip --publish
+
+# Deploy this to a specific S3 bucket for execution.
+# See alphagov/govuk-terraform-provisioning/projects/analytics_lambdas
+aws s3 cp function.zip s3://govuk-analytics-logs-production/send_public_api_events_to_ga_lambda.zip
 
 rm function.zip


### PR DESCRIPTION
Part of https://trello.com/c/nbpTiCbi/1102-publish-aws-lambda-to-process-public-api-logs

This PR changes the deployment process to upload the zipped lambda code to S3.
See https://github.com/alphagov/govuk-terraform-provisioning/pull/136 for configuration of lambda permissions.