### PR TITLE
Switch to Python 3.7 for download-lambda-logs

### DIFF
--- a/download-lambda-logs/binary_requirements.txt
+++ b/download-lambda-logs/binary_requirements.txt
@@ -1,2 +1,2 @@
-gevent==1.2.2
-greenlet==0.4.12
+gevent==1.3.4
+greenlet==0.4.13

--- a/download-lambda-logs/deploy.sh
+++ b/download-lambda-logs/deploy.sh
@@ -8,11 +8,11 @@ pip install -r requirements.txt
 
 zip -r function.zip download_logs handler.py -x *.pyc -x *.log
 (
-  cd .venv/lib/python3.6/site-packages
+  cd .venv/lib/python3.7/site-packages
   zip -r ../../../../function.zip * -x *.pyc
 )
 
-pip download --platform manylinux1_x86_64 --only-binary :all: --abi cp36m $(cat binary_requirements.txt)
+pip download --platform manylinux1_x86_64 --only-binary :all: --abi cp37m $(cat binary_requirements.txt)
 mkdir -p wheelhouse
 ls *.whl | xargs -I '{}' -n1 unzip {} -d wheelhouse
 rm *.whl


### PR DESCRIPTION
Mostly as it was easier for me to use this version of Python than 3.6.