### PR TITLE
Fix the download regex

### DIFF
--- a/download-lambda-logs/handler.py
+++ b/download-lambda-logs/handler.py
@@ -4,7 +4,7 @@ from urllib.parse import unquote
 from download_logs.aws_lambda import AWSLambda
 
 EVENT_REGEX = re.compile(r'^ObjectCreated:')
-DOWNLOAD_REGEX = re.compile(r'^whitehall_assets/')
+DOWNLOAD_REGEX = re.compile(r'^assets/')
 
 
 def handle_lambda(event, context):


### PR DESCRIPTION
The files are now downloaded from the assets/ directory, as this
includes non-whitehall assets.

This change has already been applied to the Lambda function, but
somehow wasn't committed to the repository.