### PR TITLE
Don't filter on the referrer

### DIFF
--- a/download-lambda-logs/download_logs/aws_lambda.py
+++ b/download-lambda-logs/download_logs/aws_lambda.py
@@ -23,18 +23,15 @@ class AWSLambda(Base):
     def transform_row(self, row):
         try:
             timestamp, status, file_downloaded, ip, referrer, user_agent, ga_client_id = row
-            if re.search('https://www.gov.uk/', referrer) is None:
-                return {
-                    'timestamp': timestamp,
-                    'status': status,
-                    'file_downloaded': file_downloaded,
-                    'ip': ip,
-                    'referrer': referrer,
-                    'user_agent': user_agent,
-                    'ga_client_id': ga_client_id
-                }
-            else:
-                return ""
+            return {
+                'timestamp': timestamp,
+                'status': status,
+                'file_downloaded': file_downloaded,
+                'ip': ip,
+                'referrer': referrer,
+                'user_agent': user_agent,
+                'ga_client_id': ga_client_id
+            }
         except:
             print(row)
             raise


### PR DESCRIPTION
As I don't know why this would be done. The referrer is being sent to
Google Analytics, so you should just be able to filter there.