### PR TITLE
Revert "Don't filter on the referrer"

### DIFF
--- a/download-lambda-logs/download_logs/aws_lambda.py
+++ b/download-lambda-logs/download_logs/aws_lambda.py
@@ -23,6 +23,13 @@ class AWSLambda(Base):
     def transform_row(self, row):
         try:
             timestamp, status, file_downloaded, ip, referrer, user_agent, ga_client_id = row
+
+            # We do this because this lambda is only designed to track access
+            # to an asset directly not via GOV.UK, because the latter can be
+            # tracked on GOV.UK as a click event.
+            if re.search('https://www.gov.uk/', referrer):
+                return ""
+
             return {
                 'timestamp': timestamp,
                 'status': status,


### PR DESCRIPTION
This reverts commit 4bc81669c7467aa8ec787641ee2a5f1a3c7d3d0e.

I've also added a comment to explain the reasoning by this if statement.

[Trello Card](https://trello.com/c/pkJpMWAr/1710-2-remove-unwanted-data-from-the-direct-downloads-of-assets-reports)